### PR TITLE
Handle missing simpleDB in reserveService

### DIFF
--- a/script.js
+++ b/script.js
@@ -487,8 +487,12 @@ function reserveService(serviceType) {
     }
 
     if (!whatsappNumber) {
-        const dbContact = simpleDB.get('contact');
-        whatsappNumber = dbContact?.whatsapp;
+        if (typeof simpleDB !== 'undefined') {
+            const dbContact = simpleDB.get('contact');
+            whatsappNumber = dbContact?.whatsapp;
+        } else {
+            console.warn('simpleDB not available, skipping contact from simpleDB');
+        }
     }
 
     if (!whatsappNumber) {


### PR DESCRIPTION
## Summary
- safeguard reserveService against missing simpleDB
- warn when simpleDB unavailable and fallback to local/default contact number

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c200f199d48333ab6f0a2a4b23ff1c