### PR TITLE
feat: normalize contact lookup for WhatsApp reservations

### DIFF
--- a/script.js
+++ b/script.js
@@ -480,7 +480,10 @@ function reserveService(serviceType) {
     if (storedContactRaw) {
         try {
             const storedContact = JSON.parse(storedContactRaw);
-            whatsappNumber = storedContact?.whatsapp;
+            const number = storedContact?.whatsapp || storedContact?.phone;
+            if (number) {
+                whatsappNumber = number.replace(/\D/g, '');
+            }
         } catch (e) {
             whatsappNumber = null;
         }
@@ -488,22 +491,25 @@ function reserveService(serviceType) {
 
     if (!whatsappNumber) {
         const dbContact = simpleDB.get('contact');
-        whatsappNumber = dbContact?.whatsapp;
+        const number = dbContact?.whatsapp || dbContact?.phone;
+        if (number) {
+            whatsappNumber = number.replace(/\D/g, '');
+        }
     }
 
     if (!whatsappNumber) {
         whatsappNumber = '33123456789';
     }
-    
+
     const serviceNames = {
         portrait: 'Portrait',
-        mariage: 'Mariage', 
+        mariage: 'Mariage',
         evenement: 'Événement'
     };
-    
+
     const serviceName = serviceNames[serviceType] || serviceType;
     const message = `Bonjour, je souhaite réserver une séance ${serviceName}. Pouvez-vous me donner plus d'informations sur vos disponibilités et tarifs ?`;
-    
+
     const whatsappUrl = `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(message)}`;
     window.open(whatsappUrl, '_blank');
 }


### PR DESCRIPTION
## Summary
- check `whatsapp` then `phone` when reading stored contact
- normalize numbers and keep 33123456789 as fallback

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c20108bd648333b888101eabfb3304