### PR TITLE
Avoid simpleDB undefined error in WhatsApp reservation

### DIFF
--- a/script.js
+++ b/script.js
@@ -489,20 +489,10 @@ function reserveService(serviceType) {
         }
     }
 
-    if (!whatsappNumber) {
-
+    if (!whatsappNumber && typeof simpleDB !== 'undefined') {
         const dbContact = simpleDB.get('contact');
         const number = dbContact?.whatsapp || dbContact?.phone;
-        if (number) {
-            whatsappNumber = number.replace(/\D/g, '');
-
-        if (typeof simpleDB !== 'undefined') {
-            const dbContact = simpleDB.get('contact');
-            whatsappNumber = dbContact?.whatsapp;
-        } else {
-            console.warn('simpleDB not available, skipping contact from simpleDB');
-
-        }
+        if (number) whatsappNumber = number.replace(/\D/g, '');
     }
 
     if (!whatsappNumber) {


### PR DESCRIPTION
## Summary
- Guard simpleDB access in reserveService to prevent runtime errors when simpleDB is undefined

## Testing
- `npm test` *(fails: Missing script "test")*
- `node <inline>`

------
https://chatgpt.com/codex/tasks/task_e_68c26764b0c88333a920e3157723f751