### PR TITLE
Handle invalid portfolioContact data

### DIFF
--- a/script.js
+++ b/script.js
@@ -486,6 +486,7 @@ function reserveService(serviceType) {
             }
         } catch (e) {
             whatsappNumber = null;
+            console.error('Invalid portfolioContact', e);
         }
     }
 


### PR DESCRIPTION
## Summary
- log an explicit error when `portfolioContact` in `localStorage` contains invalid JSON

## Testing
- `node - <<'NODE'
// Test snippet for reserveService invalid localStorage
const outputs=[];
const originalError=console.error;
console.error=(...args)=>{outputs.push(args.join(' ')); originalError(...args);};

global.localStorage={getItem:()=>"invalid-json"};
function reserveService(){
  let whatsappNumber=null;
  const storedContactRaw=localStorage.getItem('portfolioContact');
  if(storedContactRaw){
    try{
      const storedContact=JSON.parse(storedContactRaw);
      const number=storedContact?.whatsapp||storedContact?.phone;
      if(number){whatsappNumber=number.replace(/\D/g,'');}
    }catch(e){
      whatsappNumber=null;
      console.error('Invalid portfolioContact', e);
    }
  }
}
reserveService();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c267700e148333b3f67e9981482cda