### PR TITLE
Use same-tab WhatsApp booking and update contact info

### DIFF
--- a/data.json
+++ b/data.json
@@ -32,9 +32,9 @@
   },
   "contact": {
     "email": "photo@exemple.com",
-    "phone": "+33 1 23 45 67 89",
+    "phone": "+33 6 12 34 56 78",
     "address": "Paris, France",
-    "whatsapp": "33123456789"
+    "whatsapp": "33612345678"
   },
   "photos": []
 }

--- a/index.html
+++ b/index.html
@@ -75,21 +75,21 @@
                     <h3>Portraits</h3>
                     <p>Séances photo portrait en studio ou extérieur</p>
                     <div class="price">À partir de 150€</div>
-                    <button class="reserve-btn" onclick="reserveService('portrait')">Réserver</button>
+                    <button type="button" class="reserve-btn" onclick="reserveService('portrait')">Réserver</button>
                 </div>
                 <div class="service-card">
                     <i class="fas fa-heart"></i>
                     <h3>Mariages</h3>
                     <p>Couverture complète de votre jour J</p>
                     <div class="price">À partir de 800€</div>
-                    <button class="reserve-btn" onclick="reserveService('mariage')">Réserver</button>
+                    <button type="button" class="reserve-btn" onclick="reserveService('mariage')">Réserver</button>
                 </div>
                 <div class="service-card">
                     <i class="fas fa-calendar"></i>
                     <h3>Événements</h3>
                     <p>Reportage photo pour tous vos événements</p>
                     <div class="price">À partir de 300€</div>
-                    <button class="reserve-btn" onclick="reserveService('evenement')">Réserver</button>
+                    <button type="button" class="reserve-btn" onclick="reserveService('evenement')">Réserver</button>
                 </div>
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -510,7 +510,7 @@ function reserveService(serviceType) {
     const message = `Bonjour, je souhaite réserver une séance ${serviceName}. Pouvez-vous me donner plus d'informations sur vos disponibilités et tarifs ?`;
 
     const whatsappUrl = `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(message)}`;
-    window.open(whatsappUrl, '_blank');
+    window.location.href = whatsappUrl;
 }
 
 // Fonction pour charger depuis IndexedDB


### PR DESCRIPTION
## Summary
- Redirect WhatsApp reservations in the current tab
- Store photographer WhatsApp number in data.json
- Prevent form submission for service buttons

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c26fd9c72483338b1b71140d780f13